### PR TITLE
adds go to definition action

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,0 +1,27 @@
+module.exports = (grunt) ->
+
+    grunt.initConfig
+
+        meta:
+            src: 'lib/**/*.coffee',
+            specs: 'spec/**/*.spec.js'
+
+        watch:
+            quality:
+                files: [
+                    '<%= meta.src %>'
+                ]
+                tasks: ['coffeelint']
+
+        coffeelint:
+            app: [
+              'app/*.coffee'
+              'scripts/*.coffee'
+            ]
+
+    grunt.loadNpmTasks 'grunt-contrib-watch'
+    grunt.loadNpmTasks 'grunt-coffeelint'
+
+    grunt.registerTask 'default', ['watch']
+
+    return

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,3 @@
+git submodule update --init --recursive
+cd server
+msbuild /p:Platform="Any CPU"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+git submodule update --init --recursive
+cd server
+xbuild /p:Platform="Any CPU"

--- a/keymaps/atom-sharper.cson
+++ b/keymaps/atom-sharper.cson
@@ -10,3 +10,4 @@
 '.workspace':
   'ctrl-alt-o': 'atom-sharper:toggle'
   'ctrl-alt-r': 'atom-sharper:request'
+  'ctrl-alt-d': 'atom-sharp:go-to-definition'

--- a/lib/atom-sharper/atom-sharper.coffee
+++ b/lib/atom-sharper/atom-sharper.coffee
@@ -12,7 +12,15 @@ module.exports =
     atom.workspaceView.command "atom-sharper:toggle", => @toggle()
     atom.workspaceView.command "atom-sharper:request", _.debounce(Omni.syntaxErrors, 200)
     atom.workspaceView.command "editor:display-updated", _.debounce(Omni.syntaxErrors, 200)
-    
+    atom.workspaceView.command "atom-sharp:go-to-definition", => @goToDefinition()
+
+    atom.on "omni:navigate-to", (position) =>
+      atom.workspace.open(position.FileName).then (editor) ->
+        editor.setCursorBufferPosition [
+          position.Line
+          position.Column
+        ]
+
     createStatusEntry = =>
       @testStatusStatusBar = new AtomSharperStatusBarView
       @outputView = new AtomSharperOutputView
@@ -29,6 +37,9 @@ module.exports =
     OmniSharpServer.get().toggle()
 
   testRequest: ->
+
+  goToDefinition: ->
+    Omni.goToDefinition()
 
   deactivate: ->
     OmniSharpServer.get().stop()

--- a/lib/omni-sharp-server/omni-sharp-server.coffee
+++ b/lib/omni-sharp-server/omni-sharp-server.coffee
@@ -12,7 +12,16 @@ module.exports =
       location = "#{packageDir}/atom-sharper/server/OmniSharp/bin/Debug/OmniSharp.exe"
 
       start: () ->
-        @child = spawn("mono", [location, "-s", atom?.project?.path, "-p", @getPortNumber()])
+        useMono = process.platform isnt "win32"
+        executablePath = if useMono then "mono" else location
+        port = @getPortNumber()
+
+        serverArguments = [ "-s", atom?.project?.path, "-p", port ]
+
+        if useMono
+          serverArguments.unshift location
+
+        @child = spawn(executablePath, serverArguments)
         @child.stdout.on 'data', @out
         atom.emit("omni-sharp-server:start", @child.pid)
         @child.stderr.on 'data', @err

--- a/package.json
+++ b/package.json
@@ -15,5 +15,11 @@
     "bluebird" : "~2.3.2",
     "vue": "~0.10.6",
     "underscore": "~1.7.0"
+  },
+  "devDependencies": {
+    "coffeelint": "^1.6.0",
+    "grunt": "^0.4.5",
+    "grunt-coffeelint": "0.0.13",
+    "grunt-contrib-watch": "^0.6.1"
   }
 }


### PR DESCRIPTION
- `build.[bat|sh]` files added for pulling down OmniSharp submodule and building it
- launch OmniSharp on mono or .net
- grunt file for linting
- go to definition feature
- omni:navigate-to added
