### PR TITLE
issue#9 bugfix: Go to definition opens blank tab when definition doesn't exist

### DIFF
--- a/lib/atom-sharper/atom-sharper.coffee
+++ b/lib/atom-sharper/atom-sharper.coffee
@@ -14,7 +14,7 @@ module.exports =
     atom.workspaceView.command "atom-sharper:request", _.debounce(Omni.syntaxErrors, 200)
     atom.workspaceView.command "editor:display-updated", _.debounce(Omni.syntaxErrors, 200)
     atom.workspaceView.command "atom-sharper:go-to-definition", =>
-      @navigateToWord = @wordUnderCursor()
+      @navigateToWord = atom.workspace.getActiveEditor()?.getWordUnderCursor()
       Omni.goToDefinition()
 
     atom.on "omni:navigate-to", (position) =>
@@ -40,10 +40,6 @@ module.exports =
       createStatusEntry()
     else
       atom.packages.once 'activated', createStatusEntry
-
-  wordUnderCursor: ->
-    editor = atom.workspace.getActiveEditor()
-    editor.getWordUnderCursor()
 
   toggle: ->
     OmniSharpServer.get().toggle()


### PR DESCRIPTION
- added an `atom-sharper:error` event, currently is handled with dumb logging to console
- raises error message "Can't navigate to '{{navigateToWord}}'" when try to go to definition and none exists
  - sorts out bug where this would previous open a new blank tab
  - we might want to refactor this out a bit, not sure if should all be in main atom-sharper.coffee?
