### PR TITLE
minor fixes to build command functionality

### DIFF
--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -18,6 +18,7 @@
         { 'label': 'Rename', 'command': 'omnisharp-atom:rename'}
         { 'label': 'Fix Usings', 'command': 'omnisharp-atom:fix-usings' }
         { 'label': 'Code Format', 'command': 'omnisharp-atom:code-format' }
+        { 'label': 'Build', 'command': 'omnisharp-atom:build' }
       ]
     ]
   }

--- a/stylesheets/omnisharp-atom.less
+++ b/stylesheets/omnisharp-atom.less
@@ -87,7 +87,6 @@
 
   pre {
     background: #161719;
-    color: #fff;
     font-size: 10px;
     margin: 0px;
     padding: 0px;


### PR DESCRIPTION
- build output pane auto scrolls
    - this was conflicting with the registered filter 'ansi-to-html' for omni output.
- highlight errors in output pane (these are added with the text-error class for consistency, currently this is red, for readability we might want to leave it a neutral color and decorate with an icon on the left?)
- bug fix: build process can output more than one error message at a time, so output is now being parsed line by line to avoid chunks being treated as same error accidentally.