### PR TITLE
switch to autocomplete-plus v1.0.0 api

### DIFF
--- a/lib/omnisharp-atom/features/completion.coffee
+++ b/lib/omnisharp-atom/features/completion.coffee
@@ -2,29 +2,16 @@ CompletionProvider = require "./lib/completion-provider"
 
 module.exports =
 class Completion
-  editorSubscription: null
-  autocomplete: null
-  providers: []
+  autocompleteService: null
   constructor: ->
-    atom.packages.activatePackage("autocomplete-plus-async")
-      .then (pkg) =>
-        @autocomplete = pkg.mainModule
-        @registerProviders()
+    @registerProviders()
 
   registerProviders: ->
-    @editorSubscription = atom.workspaceView.eachEditorView (editorView) =>
-      if editorView.attached and not editorView.mini
-        provider = new CompletionProvider editorView
+    provider = new CompletionProvider
 
-        @autocomplete.registerProviderForEditorView provider, editorView
-
-        @providers.push provider
+    console.log(provider)
+    @autocompleteService = atom.services.provide 'autocomplete.provider', '1.0.0', provider: provider
 
   deactivate: ->
-    @editorSubscription?.off()
+    @autocompleteService?.dispose()
     @editorSubscription = null
-
-    @providers.forEach (provider) =>
-      @autocomplete.unregisterProvider provider
-
-    @providers = []

--- a/lib/omnisharp-atom/features/lib/completion-provider.coffee
+++ b/lib/omnisharp-atom/features/lib/completion-provider.coffee
@@ -1,28 +1,25 @@
 Omni = require '../../../omni-sharp-server/omni'
 
-{Provider, Suggestion} = require 'autocomplete-plus-async-plus'
-
 module.exports =
-  class CompletionProvider extends Provider
+  class CompletionProvider
+    selector: '.source.cs'
+    requestHandler: (options) ->
+      return new Promise (resolve) ->
+        wordRegex = /[A-Z_0-9]+/i
+        buffer = options.editor.getBuffer()
+        bufferPosition = options.editor.getCursorBufferPosition()
 
-    buildSuggestions: (cb) ->
-      wordRegex = /[A-Z_0-9]+/i
-      editor = atom.workspace.getActiveEditor()
-      buffer = editor.getBuffer()
-      bufferPosition = editor.getCursorBufferPosition()
+        end = options.position.column
 
-      end = bufferPosition.column
-
-      data = buffer.getLines()[bufferPosition.row].substring(0, end + 1)
-      end--
-
-      while wordRegex.test(data.charAt(end))
+        data = buffer.getLines()[options.position.row].substring(0, end + 1)
         end--
 
-      word = data.substring(end+1);
-      Omni.autocomplete(word)
-        .then (completions) =>
-          completions ?= []
-          suggestions =
-            (new Suggestion(this, word:item.CompletionText, label:item.DisplayText, prefix:word) for item in completions)
-          cb(suggestions)
+        while wordRegex.test(data.charAt(end))
+          end--
+
+        word = data.substring(end+1)
+        Omni.autocomplete(word)
+          .then (completions) ->
+            completions ?= []
+            suggestions = ({word:item.CompletionText, label:item.DisplayText, prefix:word} for item in completions)
+            resolve(suggestions)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "fs-plus": "^2.3.1",
     "vue": "~0.10.6",
     "underscore": "~1.7.0",
-    "autocomplete-plus-async-plus": "latest",
     "jquery": "^2.1.1",
     "omnisharp-server-binaries": "latest"
   },


### PR DESCRIPTION
@Mpdreamz, @shanselman,  The new version of autocomplete plus is going to come out tomorrow January 28th.  This represents a massive refactor in the capabilities of the autocomplete plugin, and a first round implementation of a new style of service based api.  

This pull is the basic implementation necessary to switch omnisharper off of the now defunct `autocomplete-plus-async` package.  

I highly recommend looking at https://github.com/atom-community/autocomplete-plus/wiki/Provider-API, for more information on the new capabilities of the `autocomplete-plus` api.  I'm sure you will find some things of interest. Also if you need any further assistance we are using [gitter](https://gitter.im/atom-community/autocomplete-plus) and would love to chat about any ideas you might have about the future of the api.