### PR TITLE
Update status-bar api and usage. Closes #92

### DIFF
--- a/lib/omnisharp-atom/views/status-bar-view.coffee
+++ b/lib/omnisharp-atom/views/status-bar-view.coffee
@@ -22,8 +22,7 @@ class StatusBarView extends View
       data: OmniSharpServer.vm
       methods:
         toggle: @toggle
-        
-    statusBar.addLeftTile(item: this, priority: -1000);
+    @statusBarTitle = statusBar.addLeftTile(item: this, priority: -1000);
 
   toggle: =>
     atom.commands.dispatch(atom.views.getView(atom.workspace), 'omnisharp-atom:toggle-output')
@@ -32,3 +31,5 @@ class StatusBarView extends View
   # Returns nothing.
   destroy: ->
     @detach()
+    @statusBarTile?.destroy()
+    @statusBarTile = null

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^0.58.0": "consumeStatusBar"
+        "^1.0.0": "consumeStatusBar"
       }
     }
   },


### PR DESCRIPTION
Hi,

This PR fixes problem with outdated api calls reported by Atom deprecation cop:

- bumps status-bar api dependency to 1.*
- uses updated api syntax

Can someone review, please? These are my first commits related to Atom packages.
The change in syntax is literally taken from Atom's documentation about status bar current api:
https://github.com/atom/status-bar

Thanks!