### PR TITLE
Fix wording and typos in package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 From the packages settings inside Atom:
 
 * install "Autocomplete plus" package first!
-* install "Omnisharp Atom" package
+* install "OmniSharp Atom" package
 
-From the commandline:
+From the command-line:
 
 ```
 apm install autocomplete-plus
@@ -29,5 +29,5 @@ When the flame icon in the bottom left corner turns green, the server has starte
 - `alt-F12` Go to definition
 - `shift-F12` Find usages
 - Completions appear as you type. To select an item, press the TAB key.
-- Editor addornments (squigglies) appear for errors and code hints as you type.
+- Editor adornments (squigglies) appear for errors and code hints as you type.
 - Enjoy!

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "omnisharp-atom",
   "main": "./lib/omnisharp-atom/omnisharp-atom",
   "version": "0.2.1",
-  "description": "Brings the wonderful omnisharp server to powercharge atom's C# development experience",
+  "description": "Brings the wonderful OmniSharp server to powercharge Atom's C# development experience",
   "activationEvents": [],
   "repository": "https://github.com/OmniSharp/omnisharp-atom",
   "license": "MIT",


### PR DESCRIPTION
Hi, 
This PR fixes some visual problems with wording in official, user-facing documents:

- fix typos
- use consistent naming conventions

Thanks!