### PR TITLE
migrate linter to use lodash from underscore

### DIFF
--- a/lib/omnisharp-atom/linter.coffee
+++ b/lib/omnisharp-atom/linter.coffee
@@ -3,7 +3,7 @@ Linter = require "#{linterPath}/lib/linter"
 Rng = require("atom").Range;
 OmniSharpServer = require '../omni-sharp-server/omni-sharp-server'
 Omni = require '../omni-sharp-server/omni'
-_ = require 'underscore'
+_ = require 'lodash'
 
 class LinterCSharp extends Linter
 


### PR DESCRIPTION
The linter bits missed the memo on the lodash migration.