### PR TITLE
Fixed context menu and added missing items

### DIFF
--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -2,7 +2,7 @@
 'context-menu':
   'atom-text-editor': [
     {
-      label: 'omnisharp-atom'
+      label: 'OmniSharp'
       submenu: [
         { 'label': 'Toggle', 'command': 'omnisharp-atom:toggle' }
         { 'label': 'Find Usages', 'command': 'omnisharp-atom:find-usages' }
@@ -14,12 +14,12 @@
       ]
     }
   ]
-  
+
 'menu': [
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'omnisharp-atom'
+      'label': 'OmniSharp'
       'submenu': [
         { 'label': 'Toggle', 'command': 'omnisharp-atom:toggle' }
         { 'label': 'Find Usages', 'command': 'omnisharp-atom:find-usages' }

--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -1,11 +1,20 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'atom-sharp':
-        'Enable atom-sharp': 'omnisharp-atom:toggle'
-        'Find Usages': 'omnisharp-atom:find-usages'
-        'Rename': 'omnisharp-atom:rename'
-
+  'atom-text-editor': [
+    {
+      label: 'omnisharp-atom'
+      submenu: [
+        { 'label': 'Toggle', 'command': 'omnisharp-atom:toggle' }
+        { 'label': 'Find Usages', 'command': 'omnisharp-atom:find-usages' }
+        { 'label': 'Go to definition', 'command': 'omnisharp-atom:go-to-definition' }
+        { 'label': 'Rename', 'command': 'omnisharp-atom:rename'}
+        { 'label': 'Fix Usings', 'command': 'omnisharp-atom:fix-usings' }
+        { 'label': 'Code Format', 'command': 'omnisharp-atom:code-format' }
+        { 'label': 'Build', 'command': 'omnisharp-atom:build' }
+      ]
+    }
+  ]
+  
 'menu': [
   {
     'label': 'Packages'


### PR DESCRIPTION
This fixes the context menu so that it works again.

It's editor only. We can add it to the tree view, but I think if we do that we should change the options. Showing a "go to definition" doesn't make sense in the tree view.

Closes #109 