### PR TITLE
"File -> New Project"

### DIFF
--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -41,6 +41,7 @@ class OmniSharpAtom {
     private autoCompleteProvider;
     private statusBar;
     private generator: { run(generator: string, path?: string): void; start(prefix: string, path?:string): void;  };
+    private menu: EventKit.Disposable;
 
     public activate(state) {
         atom.commands.add('atom-workspace', 'omnisharp-atom:toggle', () => this.toggle());
@@ -114,8 +115,18 @@ class OmniSharpAtom {
     }
 
     public toggle() {
+        var menuJsonFile = this.getPackageDir() + "/omnisharp-atom/menus/omnisharp-menu.json";
+        var menuJson = JSON.parse(fs.readFileSync(menuJsonFile, 'utf8'));
+
+
         var dependencyErrors = dependencyChecker.errors();
         if (dependencyErrors.length === 0) {
+            if (OmniSharpServer.vm.isOff) {
+                this.menu = atom.menu.add(menuJson.menu);
+            } else if (this.menu) {
+                this.menu.dispose();
+                this.menu = null;
+            }
             return OmniSharpServer.get().toggle();
         } else {
             return _.map(dependencyErrors, missingDependency => alert(missingDependency));

--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -40,9 +40,12 @@ class OmniSharpAtom {
     public outputView;
     private autoCompleteProvider;
     private statusBar;
+    private generator: { run(generator: string, path?: string): void; start(prefix: string, path?:string): void;  };
 
     public activate(state) {
         atom.commands.add('atom-workspace', 'omnisharp-atom:toggle', () => this.toggle());
+        atom.commands.add('atom-workspace', 'omnisharp-atom:new-application', () => this.generator.run("aspnet:app"));
+        atom.commands.add('atom-workspace', 'omnisharp-atom:new-class', () => this.generator.run("aspnet:Class"));
 
         if (dependencyChecker.findAllDeps(this.getPackageDir())) {
             this.emitter = new Emitter;
@@ -135,6 +138,12 @@ class OmniSharpAtom {
     public consumeStatusBar(statusBar) {
         this.statusBarView = new StatusBarView(statusBar);
         this.outputView = new DockView(this);
+    }
+
+    public consumeYeomanEnvironment(generatorService : { run(generator: string, path: string): void; start(prefix: string, path:string): void;  }) {
+
+        console.log('generatorService')
+        this.generator = generatorService;
     }
 
     public provideAutocomplete() {

--- a/lib/omnisharp-atom/views/rename-view.ts
+++ b/lib/omnisharp-atom/views/rename-view.ts
@@ -25,7 +25,7 @@ class RenameView extends spacePenViews.View {
 
     public initialize() {
         this.on('core:confirm', () => this.rename());
-        return this.on('core:cancel', () => this.destroy());
+        this.on('core:cancel', () => this.destroy());
     }
 
     public configure(wordToRename) {

--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -22,7 +22,7 @@
     'submenu': [
       'label': 'OmniSharp'
       'submenu': [
-        { "label": "Toggle", "command": "omnisharp-atom:toggle" },
+        { "label": "Toggle", "command": "omnisharp-atom:toggle" }
         { 'label': 'New Application', 'command': 'omnisharp-atom:new-application' }
       ]
     ]

--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -22,6 +22,7 @@
     'submenu': [
       'label': 'OmniSharp'
       'submenu': [
+        { "label": "Toggle", "command": "omnisharp-atom:toggle" },
         { 'label': 'New Application', 'command': 'omnisharp-atom:new-application' }
       ]
     ]

--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -30,6 +30,7 @@
         { 'label': 'Fix Usings', 'command': 'omnisharp-atom:fix-usings' }
         { 'label': 'Code Format', 'command': 'omnisharp-atom:code-format' }
         { 'label': 'Build', 'command': 'omnisharp-atom:build' }
+        { 'label': 'New Application', 'command': 'omnisharp-atom:new-application' }
       ]
     ]
   }

--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -22,14 +22,6 @@
     'submenu': [
       'label': 'OmniSharp'
       'submenu': [
-        { 'label': 'Toggle', 'command': 'omnisharp-atom:toggle' }
-        { 'label': 'Find Usages', 'command': 'omnisharp-atom:find-usages' }
-        { 'label': 'Go to definition', 'command': 'omnisharp-atom:go-to-definition' }
-        { 'label': 'Go to implementation', 'command': 'omnisharp-atom:go-to-implementation' }
-        { 'label': 'Rename', 'command': 'omnisharp-atom:rename'}
-        { 'label': 'Fix Usings', 'command': 'omnisharp-atom:fix-usings' }
-        { 'label': 'Code Format', 'command': 'omnisharp-atom:code-format' }
-        { 'label': 'Build', 'command': 'omnisharp-atom:build' }
         { 'label': 'New Application', 'command': 'omnisharp-atom:new-application' }
       ]
     ]

--- a/menus/omnisharp-menu.json
+++ b/menus/omnisharp-menu.json
@@ -1,0 +1,14 @@
+{
+  "menu": [{
+    "label": "&OmniSharp",
+    "submenu": [
+      { "label": "Toggle", "command": "omnisharp-atom:toggle" },
+      { "label": "Find Usages", "command": "omnisharp-atom:find-usages" },
+      { "label": "Go to Definition", "command": "omnisharp-atom:go-to-definition" },
+      { "label": "Go to Implementation", "command": "omnisharp-atom:go-to-implementation" },
+      { "label": "Rename", "command": "omnisharp-atom:rename"},
+      { "label": "Fix Usings", "command": "omnisharp-atom:fix-usings" },
+      { "label": "Code Format", "command": "omnisharp-atom:code-format" }
+    ]
+  }]
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "https://github.com/OmniSharp/omnisharp-atom",
   "author": {
     "name": "Omnisharp Atom Team",
-    "url": "https://github.com/OmniSharp/omnisharp-atom/graphs/contributors"
+    "url":  "https://github.com/OmniSharp/omnisharp-atom/graphs/contributors"
   },
   "contributors": [
     {
@@ -49,6 +49,7 @@
     "atom": ">=0.192.0 <2.0.0"
   },
   "activationCommands": [],
+  "menus": ["atom-sharper.cson"],
   "linter-package": true,
   "linter-implementation": "omnisharp-atom/linter",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,18 +61,26 @@
     "bluebird": "~2.3.2",
     "event-kit": "0.7.2",
     "fs-plus": "^2.3.1",
+    "generator-aspnet": "0.0.32",
     "jquery": "^2.1.1",
     "lodash": "^3.6.0",
     "omnisharp-server-roslyn-binaries": "latest",
     "request-promise": "~0.1.2",
     "semver": "^4.2.0",
     "tsd": "~0.6.0-beta.5",
-    "vue": "~0.10.6"
+    "vue": "~0.10.6",
+    "yeoman-environment": "^1.2.5",
+    "yo": "^1.4.6"
   },
   "consumedServices": {
     "status-bar": {
       "versions": {
         "^1.0.0": "consumeStatusBar"
+      }
+    },
+    "yeoman-environment": {
+      "versions": {
+        "^1.0.0": "consumeYeomanEnvironment"
       }
     }
   },

--- a/typingsTemp/atom/atom.d.ts
+++ b/typingsTemp/atom/atom.d.ts
@@ -83,7 +83,7 @@ located if it exists.
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        static getCurrentWindow() : any;
+        static getCurrentWindow() : AtomWindow;
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -312,7 +312,7 @@ if the window hasn't finished loading yet.
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        getCurrentWindow() : any;
+        getCurrentWindow() : AtomWindow;
     
         /**
          * Move current window to the center of the screen. 
@@ -3940,7 +3940,7 @@ file in the type specified by the configuration schema.
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        createToken(value? : any, scopes? : Scope[]) : Token;
+        createToken(value? : any, scopes? : Token[]) : Token;
     
         /**
          * Select a grammar for the given file path and file contents.
@@ -6970,7 +6970,7 @@ added menu items.
         /**
          * Get an {Array} of {Directory}s associated with this project. 
          */
-        getDirectories() : any;
+        getDirectories() : Pathwatcher.Directory[];
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -12443,7 +12443,7 @@ required stylesheet.
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        buildSoftWrapIndentationTokens(token? : Token, hangingIndent? : any) : Token[];
+        buildSoftWrapIndentationTokens(token? : Token[], hangingIndent? : any) : Token[];
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -12622,7 +12622,7 @@ tooltip.
         Returns a {Disposable} on which `.dispose()` can be called to remove the
 added provider.
          */
-        addViewProvider(modelConstructor? : any, createView? : SpacePen.View) : EventKit.Disposable;
+        addViewProvider(modelConstructor? : any, createView? : (model: any) => HTMLElement) : EventKit.Disposable;
     
         /**
          * Get the view associated with an object in the workspace.
@@ -12637,7 +12637,7 @@ added provider.
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        createView(object? : any) : SpacePen.View;
+        createView(object? : any) : (model: any) => HTMLElement;
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -13274,7 +13274,7 @@ opener.
          * Adds a panel item to the bottom of the editor window.
          * @param options? - {Object}
          */
-        addBottomPanel(options? : Object) : Panel;
+        addBottomPanel(options? : { item: Node | JQuery | Object; visible?: boolean; priority?: number; }) : Panel;
     
         /**
          * Get an {Array} of all the panel items to the left of the editor window. 
@@ -13285,7 +13285,7 @@ opener.
          * Adds a panel item to the left of the editor window.
          * @param options? - {Object}
          */
-        addLeftPanel(options? : Object) : Panel;
+        addLeftPanel(options? : { item: Node | JQuery | Object; visible?: boolean; priority?: number; }) : Panel;
     
         /**
          * Get an {Array} of all the panel items to the right of the editor window. 
@@ -13296,7 +13296,7 @@ opener.
          * Adds a panel item to the right of the editor window.
          * @param options? - {Object}
          */
-        addRightPanel(options? : Object) : Panel;
+        addRightPanel(options? : { item: Node | JQuery | Object; visible?: boolean; priority?: number; }) : Panel;
     
         /**
          * Get an {Array} of all the panel items at the top of the editor window. 
@@ -13307,7 +13307,7 @@ opener.
          * Adds a panel item to the top of the editor window above the tabs.
          * @param options? - {Object}
          */
-        addTopPanel(options? : Object) : Panel;
+        addTopPanel(options? : { item: Node | JQuery | Object; visible?: boolean; priority?: number; }) : Panel;
     
         /**
          * Get an {Array} of all the modal panel items 
@@ -13318,7 +13318,7 @@ opener.
          * Adds a panel item as a modal dialog.
          * @param options? - {Object}
          */
-        addModalPanel(options? : Object) : Panel;
+        addModalPanel(options? : { item: Node | JQuery | Object; visible?: boolean; priority?: number; }) : Panel;
     
         panelForItem(item? : any) : Panel | any;
     

--- a/typingsTemp/first-mate/first-mate.d.ts
+++ b/typingsTemp/first-mate/first-mate.d.ts
@@ -127,7 +127,7 @@ declare module FirstMate {
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        createToken(value? : any, scopes? : Atom.Scope[]) : Atom.Token;
+        createToken(value? : any, scopes? : Atom.Token[]) : Atom.Token;
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -241,7 +241,7 @@ declare module FirstMate {
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        createToken(value? : any, scopes? : Atom.Scope[]) : Atom.Token;
+        createToken(value? : any, scopes? : Atom.Token[]) : Atom.Token;
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -359,7 +359,7 @@ declare module FirstMate {
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        getIncludedPatterns(baseGrammar? : Grammar, included? : any) : Pattern[];
+        getIncludedPatterns(baseGrammar? : Pattern[], included? : any) : Pattern[];
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
@@ -374,7 +374,7 @@ declare module FirstMate {
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        getTokensForCaptureRule(rule? : Rule, line? : any, captureStart? : any, captureEnd? : any, scopes? : Atom.Scope[], stack? : any) : Rule;
+        getTokensForCaptureRule(rule? : Rule, line? : any, captureStart? : any, captureEnd? : any, scopes? : Rule[], stack? : any) : Rule;
     
         /**
          * Get the tokens for the capture indices.
@@ -438,7 +438,7 @@ declare module FirstMate {
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.
          */
-        getIncludedPatterns(baseGrammar? : Grammar, included? : any) : Pattern[];
+        getIncludedPatterns(baseGrammar? : Pattern[], included? : any) : Pattern[];
     
         /**
          * This field or method was not documented by atomdoc, assume it is private. Use with caution.

--- a/typingsTemp/space-pen/space-pen.d.ts
+++ b/typingsTemp/space-pen/space-pen.d.ts
@@ -785,7 +785,6 @@ declare module SpacePen {
         * @param duration A string or number determining how long the animation will run.
         * @param complete A function to call once the animation is complete.
         */
-        hide(duration?: number|string, complete?: Function): JQuery;
         /**
         * Hide the matched elements.
         *
@@ -793,13 +792,11 @@ declare module SpacePen {
         * @param easing A string indicating which easing function to use for the transition.
         * @param complete A function to call once the animation is complete.
         */
-        hide(duration?: number|string, easing?: string, complete?: Function): JQuery;
         /**
         * Hide the matched elements.
         *
         * @param options A map of additional options to pass to the method.
         */
-        hide(options: JQueryAnimationOptions): JQuery;
         
         /**
         * Display the matched elements.
@@ -807,7 +804,6 @@ declare module SpacePen {
         * @param duration A string or number determining how long the animation will run.
         * @param complete A function to call once the animation is complete.
         */
-        show(duration?: number|string, complete?: Function): JQuery;
         /**
         * Display the matched elements.
         *
@@ -815,13 +811,11 @@ declare module SpacePen {
         * @param easing A string indicating which easing function to use for the transition.
         * @param complete A function to call once the animation is complete.
         */
-        show(duration?: number|string, easing?: string, complete?: Function): JQuery;
         /**
         * Display the matched elements.
         *
         * @param options A map of additional options to pass to the method.
         */
-        show(options: JQueryAnimationOptions): JQuery;
         
         /**
         * Display the matched elements with a sliding motion.
@@ -911,7 +905,6 @@ declare module SpacePen {
         * @param duration A string or number determining how long the animation will run.
         * @param complete A function to call once the animation is complete.
         */
-        toggle(duration?: number|string, complete?: Function): JQuery;
         /**
         * Display or hide the matched elements.
         *
@@ -919,19 +912,16 @@ declare module SpacePen {
         * @param easing A string indicating which easing function to use for the transition.
         * @param complete A function to call once the animation is complete.
         */
-        toggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
         /**
         * Display or hide the matched elements.
         *
         * @param options A map of additional options to pass to the method.
         */
-        toggle(options: JQueryAnimationOptions): JQuery;
         /**
         * Display or hide the matched elements.
         *
         * @param showOrHide A Boolean indicating whether to show or hide the elements.
         */
-        toggle(showOrHide: boolean): JQuery;
         
         /**
         * Attach a handler to an event for the elements.
@@ -2227,6 +2217,9 @@ declare module SpacePen {
         * @param callback The new function to add to the queue, with a function to call that will dequeue the next item.
         */
         queue(queueName: string, callback: Function): JQuery;
+        hide(): void;
+        show(): void;
+        toggle(): void;
     }
 
     /**


### PR DESCRIPTION
So we can't really do much to change the internals of the menu that atom hands off to the os.  Soooo I think this is a decent compromise.

The only menu item in `Packages -> OmniSharp` is now "New Application".  Then when OmniSharp is running a new top level menu is added after Help called "OmniSharp".  This has the build menu, rename, code format and other menu items in it.  When Omnisharp is turned off, the menu goes away.