### PR TITLE
revised keymaps

### DIFF
--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -13,10 +13,12 @@
   'ctrl-alt-x': 'omnisharp-atom:show-omni'
   'ctrl-alt-e': 'omnisharp-atom:show-errors'
   'ctrl-alt-b': 'omnisharp-atom:show-build'
+  'ctrl-shift-b': 'omnisharp-atom:build'
+
+'atom-text-editor:not([mini])[data-grammar~="cs"]':
   'alt-F12': 'omnisharp-atom:go-to-definition'
   'shift-F12': 'omnisharp-atom:find-usages'
   'ctrl-alt-u': 'omnisharp-atom:fix-usings'
   'ctrl-alt-m': 'omnisharp-atom:code-format'
   'alt-r': 'omnisharp-atom:rename'
-  'ctrl-shift-b': 'omnisharp-atom:build'
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'


### PR DESCRIPTION
Fixes #173 

Have kept the triggering of the statusbar globals, but moved the code specific ones to only occur under the C# grammar.