### PR TITLE
Enable autocompletion for scriptcs file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ apm install omnisharp-atom
 
 - Open a c# file
 
+- or open a scriptcs file
+
 When the flame icon in the bottom left corner turns green, the server has started!
 
 # Features

--- a/lib/omnisharp-atom/features/lib/completion-provider.ts
+++ b/lib/omnisharp-atom/features/lib/completion-provider.ts
@@ -31,7 +31,7 @@ export interface Suggestion {
 
 export var CompletionProvider = {
 
-    selector: '.source.cs',
+    selector: '.source.cs, .source.csx',
     disableForSelector: 'source.cs .comment',
 
     inclusionPriority: 1,

--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -99,7 +99,7 @@ class OmniSharpAtom {
         this.observeEditors = atom.workspace.observeTextEditors((editor: Atom.TextEditor) => {
             var editorFilePath;
             var grammarName = editor.getGrammar().name;
-            if (grammarName === 'C#') {
+            if (grammarName === 'C#' || grammarName === 'C# Script File') {
                 this.emitter.emit('omnisharp-atom-editor', editor);
                 editorFilePath = editor.buffer.file.path;
                 editor.onDidDestroy(() => this.emitter.emit('omnisharp-atom-editor-destroyed', editorFilePath));


### PR DESCRIPTION
Since omnisharp-roslyn has support for scriptcs files, this PR enables autocompletion for csx files.