### PR TITLE
Fixed atom api deprecations

### DIFF
--- a/lib/omnisharp-atom/views/dock-view.ts
+++ b/lib/omnisharp-atom/views/dock-view.ts
@@ -118,7 +118,8 @@ class DockView extends spacePenViews.View {
         atom.commands.add('atom-workspace', "omnisharp-atom:show-build", () => this.selectPane("build"));
         atom.commands.add('atom-workspace', "omnisharp-atom:show-omni", () => this.selectPane("omni"));
 
-        this.on('core:cancel core:close', () => this.hideView());
+        atom.commands.add('atom-workspace', 'core:close', () => this.hideView());
+        atom.commands.add('atom-workspace', 'core:cancel', () => this.hideView());
 
         this.on('mousedown', '.omnisharp-atom-output-resizer', e => this.resizeStarted(e));
 

--- a/lib/omnisharp-atom/views/rename-view.ts
+++ b/lib/omnisharp-atom/views/rename-view.ts
@@ -24,8 +24,8 @@ class RenameView extends spacePenViews.View {
     }
 
     public initialize() {
-        this.on('core:confirm', () => this.rename());
-        this.on('core:cancel', () => this.destroy());
+        atom.commands.add('workspace', 'core:confirm', () => this.rename());
+        atom.commands.add('workspace', 'core:cancel', () => this.destroy());
     }
 
     public configure(wordToRename) {


### PR DESCRIPTION
This should close #101. Atom is going to remove those API calls, so time to get the last ones removed.

I don't see omnisharp-atom deprecations with these two changes.