### PR TITLE
Format on keystroke

### DIFF
--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -20,5 +20,9 @@
   'shift-F12': 'omnisharp-atom:find-usages'
   'ctrl-alt-u': 'omnisharp-atom:fix-usings'
   'ctrl-alt-m': 'omnisharp-atom:code-format'
+  ';': 'omnisharp-atom:code-format-on-semicolon'
+  '}': 'omnisharp-atom:code-format-on-curly-brace'
+
   'alt-r': 'omnisharp-atom:rename'
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'
+  'enter': 'omnisharp-atom:code-format-on-enter'

--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -24,4 +24,3 @@
   '}': 'omnisharp-atom:code-format-on-curly-brace'
   'alt-r': 'omnisharp-atom:rename'
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'
-  'enter': 'omnisharp-atom:code-format-on-enter'

--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -22,7 +22,6 @@
   'ctrl-alt-m': 'omnisharp-atom:code-format'
   ';': 'omnisharp-atom:code-format-on-semicolon'
   '}': 'omnisharp-atom:code-format-on-curly-brace'
-
   'alt-r': 'omnisharp-atom:rename'
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'
   'enter': 'omnisharp-atom:code-format-on-enter'

--- a/lib/omnisharp-atom/features/code-format.ts
+++ b/lib/omnisharp-atom/features/code-format.ts
@@ -33,15 +33,6 @@ class CodeFormat {
                 .then((data) => {
                 var buffer = editor.getBuffer();
 
-                /*var changes = data.Changes.sort((change1, change2) => {
-                    if (change1.EndLine > change2.EndLine) return 1;
-                    if (change2.EndLine > change1.EndLine) return -1;
-                    if (change1.EndColumn > change2.EndColumn) return 1;
-                    if (change2.EndColumn > change1.EndColumn) return -1;
-
-                    return 0;
-                });*/
-
                 data.Changes.forEach((change) => {
                     var range = new Range([change.StartLine - 1, change.StartColumn - 1], [change.EndLine - 1, change.EndColumn - 1]);
                     buffer.setTextInRange(range, change.NewText);


### PR DESCRIPTION
Adds automatic formatting when you press ; or }. I wanted to add <enter> too, but the server has some issues with this key that need to be fixed. Will add that later.
![formatbrace](https://cloud.githubusercontent.com/assets/667194/7496356/8f8f772e-f40b-11e4-8edb-f2c65ed748e3.gif)
![formatsemicolon](https://cloud.githubusercontent.com/assets/667194/7496360/919c91b4-f40b-11e4-8053-dae5f7124346.gif)

