### PR TITLE
Expose the type lookup functionality on a command with keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ When the flame icon in the bottom left corner turns green, the server has starte
 - `ctrl-F12` Go to implementation
 - `shift-F12` Find usages
 - Completions appear as you type. To select an item, press the TAB key.
+- Type lookup on mouse over or from cursor (`f1`).
 - Editor adornments (squigglies) appear for errors and code hints as you type.
 - Automatic Package restore in vNext when you save `project.json` files
 - Enjoy!

--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -22,3 +22,4 @@
   'ctrl-alt-m': 'omnisharp-atom:code-format'
   'alt-r': 'omnisharp-atom:rename'
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'
+  'f1': 'omnisharp-atom:type-lookup'

--- a/lib/omnisharp-atom/views/tooltip-view.ts
+++ b/lib/omnisharp-atom/views/tooltip-view.ts
@@ -26,6 +26,7 @@ class TooltipView extends spacePen.View {
 
     updateText(text: string) {
         this.inner.html(text);
+        this.inner.css({'white-space' : 'pre'});
         this.updatePosition();
         this.fadeTo(300, 1);
     }

--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -11,6 +11,7 @@
         { 'label': 'Rename', 'command': 'omnisharp-atom:rename'}
         { 'label': 'Fix Usings', 'command': 'omnisharp-atom:fix-usings' }
         { 'label': 'Code Format', 'command': 'omnisharp-atom:code-format' }
+        { 'label': 'Lookup type', 'command': 'omnisharp-atom:type-lookup' }
       ]
     }
   ]

--- a/menus/omnisharp-menu.json
+++ b/menus/omnisharp-menu.json
@@ -8,7 +8,8 @@
       { "label": "Go to Implementation", "command": "omnisharp-atom:go-to-implementation" },
       { "label": "Rename", "command": "omnisharp-atom:rename"},
       { "label": "Fix Usings", "command": "omnisharp-atom:fix-usings" },
-      { "label": "Code Format", "command": "omnisharp-atom:code-format" }
+      { "label": "Code Format", "command": "omnisharp-atom:code-format" },
+      { "label": "Lookup type", "command": "omnisharp-atom:type-lookup" }
     ]
   }]
 }


### PR DESCRIPTION
Pressing F1 will open the tooltip below the cursor. Moving the mouse or cursor will dismiss it like before. 

Also fixes a small issue with formatting of line-breaks in tooltips (they were being ignored). 

![typelookup](https://cloud.githubusercontent.com/assets/1052521/7498470/4bd105dc-f421-11e4-999f-1b8b0376d3a6.gif)

