### PR TITLE
Intellisense keys (make '.' work)

### DIFF
--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -25,3 +25,8 @@
   'alt-r': 'omnisharp-atom:rename'
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'
   'f1': 'omnisharp-atom:type-lookup'
+
+'atom-text-editor.autocomplete-active:not([mini])[data-grammar~="cs"]':
+  'space': 'omnisharp-atom:intellisense-space'
+  '.': 'omnisharp-atom:intellisense-dot'
+  'enter': 'autocomplete-plus:confirm'

--- a/keymaps/omnisharp-atom.cson
+++ b/keymaps/omnisharp-atom.cson
@@ -15,7 +15,7 @@
   'ctrl-alt-b': 'omnisharp-atom:show-build'
   'ctrl-shift-b': 'omnisharp-atom:build'
 
-'atom-text-editor:not([mini])[data-grammar~="cs"]':
+'atom-text-editor:not([mini])[data-grammar~="cs"], atom-text-editor:not([mini])[data-grammar~="csx"]':
   'alt-F12': 'omnisharp-atom:go-to-definition'
   'shift-F12': 'omnisharp-atom:find-usages'
   'ctrl-alt-u': 'omnisharp-atom:fix-usings'
@@ -26,7 +26,7 @@
   'ctrl-F12': 'omnisharp-atom:go-to-implementation'
   'f1': 'omnisharp-atom:type-lookup'
 
-'atom-text-editor.autocomplete-active:not([mini])[data-grammar~="cs"]':
+'.autocomplete-active:not([mini])[data-grammar~="cs"], .autocomplete-active:not([mini])[data-grammar~="csx"]':
   'space': 'omnisharp-atom:intellisense-space'
   '.': 'omnisharp-atom:intellisense-dot'
   'enter': 'autocomplete-plus:confirm'

--- a/lib/omnisharp-atom/features/intellisense.ts
+++ b/lib/omnisharp-atom/features/intellisense.ts
@@ -1,0 +1,26 @@
+import Omni = require('../../omni-sharp-server/omni')
+
+class Intellisense {
+
+    public activate() {
+        atom.commands.add('atom-workspace', 'omnisharp-atom:intellisense-dot',
+            (event) => this.complete(event, '.'));
+
+        atom.commands.add('atom-workspace', 'omnisharp-atom:intellisense-space',
+            (event) => this.complete(event, ' '));
+    }
+
+    private complete(event: Event, char: string) {
+        var editor = atom.workspace.getActiveTextEditor();
+        if (editor) {
+            var view = atom.views.getView(editor);
+            atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:confirm');
+            editor.insertText(char);
+            if (char == '.') {
+                setTimeout(() => 
+                    atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:activate') , 0);
+            }
+        }
+    }
+}
+export = Intellisense

--- a/lib/omnisharp-atom/features/intellisense.ts
+++ b/lib/omnisharp-atom/features/intellisense.ts
@@ -4,7 +4,11 @@ class Intellisense {
 
     public activate() {
         atom.commands.add('atom-workspace', 'omnisharp-atom:intellisense-dot',
-            (event) => this.complete(event, '.'));
+            (event) => {
+                this.complete(event, '.');
+                setTimeout(() =>
+                    atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'autocomplete-plus:activate'), 0);
+            });
 
         atom.commands.add('atom-workspace', 'omnisharp-atom:intellisense-space',
             (event) => this.complete(event, ' '));
@@ -16,10 +20,6 @@ class Intellisense {
             var view = atom.views.getView(editor);
             atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:confirm');
             editor.insertText(char);
-            if (char == '.') {
-                setTimeout(() => 
-                    atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:activate') , 0);
-            }
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
         "./lib/omnisharp-atom/features/find-usages.ts",
         "./lib/omnisharp-atom/features/go-to-definition.ts",
         "./lib/omnisharp-atom/features/go-to-implementation.ts",
+        "./lib/omnisharp-atom/features/intellisense.ts",
         "./lib/omnisharp-atom/features/lib/completion-provider.ts",
         "./lib/omnisharp-atom/features/lookup.ts",
         "./lib/omnisharp-atom/features/package-restore.ts",


### PR DESCRIPTION
This PR makes the '.' key work like it does in VS. 

![intellisense-dot](https://cloud.githubusercontent.com/assets/667194/7520621/e455c4d2-f4df-11e4-847e-60b151fb2244.gif)

It also closes the popup on space key.