### PR TITLE
only treat .ts files as features

### DIFF
--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -90,7 +90,7 @@ class OmniSharpAtom {
         var featureDir = packageDir + "/omnisharp-atom/lib/omnisharp-atom/features";
         var featureFiles = _.filter(
             fs.readdirSync(featureDir),
-            (file: string) => !fs.statSync(featureDir + "/" + file).isDirectory()
+            (file: string) => !fs.statSync(featureDir + "/" + file).isDirectory() && /\.ts$/.test(file)
             );
 
         var features = _.map(featureFiles, (feature: string) => new Feature(this, feature));


### PR DESCRIPTION
![screen shot 2015-05-10 at 14 37 03](https://cloud.githubusercontent.com/assets/667194/7554533/02ae654c-f724-11e4-9104-7877a2c9d72b.png)

When we have a mixture of .js and .ts files, they each counted as a separate feature, hence 2 subscriptions.
