### PR TITLE
Rename changes

### DIFF
--- a/lib/omnisharp-atom/features/code-format.ts
+++ b/lib/omnisharp-atom/features/code-format.ts
@@ -1,6 +1,5 @@
 import Omni = require('../../omni-sharp-server/omni')
-
-var Range = require("atom").Range;
+import applyChanges = require('./lib/apply-changes');
 
 class CodeFormat {
 
@@ -31,12 +30,7 @@ class CodeFormat {
 
             Omni.client.formatAfterKeystrokePromise(request)
                 .then((data) => {
-                var buffer = editor.getBuffer();
-
-                data.Changes.forEach((change) => {
-                    var range = new Range([change.StartLine - 1, change.StartColumn - 1], [change.EndLine - 1, change.EndColumn - 1]);
-                    buffer.setTextInRange(range, change.NewText);
-                });
+                applyChanges(editor, data.Changes);
             });
         }
         event.preventDefault();

--- a/lib/omnisharp-atom/features/lib/apply-changes.ts
+++ b/lib/omnisharp-atom/features/lib/apply-changes.ts
@@ -3,11 +3,12 @@ var Range = require('atom').Range;
 class Changes {
     public static applyChanges(editor: Atom.TextEditor, changes: OmniSharp.Models.LinePositionSpanTextChange[]) {
         var buffer = editor.getBuffer();
-
+        var checkpoint = buffer.createCheckpoint();
         changes.forEach((change) => {
             var range = new Range([change.StartLine - 1, change.StartColumn - 1], [change.EndLine - 1, change.EndColumn - 1]);
             buffer.setTextInRange(range, change.NewText);
         });
+        buffer.groupChangesSinceCheckpoint(checkpoint);
     }
 }
 

--- a/lib/omnisharp-atom/features/lib/apply-changes.ts
+++ b/lib/omnisharp-atom/features/lib/apply-changes.ts
@@ -1,0 +1,14 @@
+var Range = require('atom').Range;
+
+class Changes {
+    public static applyChanges(editor: Atom.TextEditor, changes: OmniSharp.Models.LinePositionSpanTextChange[]) {
+        var buffer = editor.getBuffer();
+
+        changes.forEach((change) => {
+            var range = new Range([change.StartLine - 1, change.StartColumn - 1], [change.EndLine - 1, change.EndColumn - 1]);
+            buffer.setTextInRange(range, change.NewText);
+        });
+    }
+}
+
+export = Changes.applyChanges

--- a/lib/omnisharp-atom/features/lib/apply-changes.ts
+++ b/lib/omnisharp-atom/features/lib/apply-changes.ts
@@ -11,4 +11,4 @@ class Changes {
     }
 }
 
-export = Changes.applyChanges
+export = Changes

--- a/lib/omnisharp-atom/features/rename.ts
+++ b/lib/omnisharp-atom/features/rename.ts
@@ -16,10 +16,7 @@ class Rename {
         });
         Omni.registerConfiguration(client => {
             client.observeRename.subscribe((data) => {
-                // events are firing twice sometimes but not always.
-                // applying changes twice is _really_ bad.
-                // I have no idea why yet :(
-                _.debounce(this.applyAllChanges(data.response.Changes), 20);
+                this.applyAllChanges(data.response.Changes);
             })
         });
     }

--- a/lib/omnisharp-atom/features/rename.ts
+++ b/lib/omnisharp-atom/features/rename.ts
@@ -1,6 +1,7 @@
 import _ = require('lodash')
 import RenameView = require('../views/rename-view')
 import Omni = require('../../omni-sharp-server/omni')
+import applyChanges = require('./lib/apply-changes')
 
 class Rename {
     private renameView: RenameView
@@ -15,7 +16,7 @@ class Rename {
         });
         Omni.registerConfiguration(client => {
             client.observeRename.subscribe((data) => {
-                this.applyChanges(data.response.Changes)
+                this.applyAllChanges(data.response.Changes)
             })
         });
     }
@@ -31,9 +32,9 @@ class Rename {
         return this.renameView.configure(wordToRename);
     }
 
-    public applyChanges(changes: any[]) {
+    public applyAllChanges(changes: any[]) {
         return _.each(changes, (change) => atom.workspace.open(change.FileName, undefined)
-            .then((editor) => editor.setText(change.Buffer)))
+            .then((editor) => { applyChanges(editor, change.Changes) }))
     }
 }
 export =  Rename

--- a/lib/omnisharp-atom/features/rename.ts
+++ b/lib/omnisharp-atom/features/rename.ts
@@ -1,7 +1,7 @@
 import _ = require('lodash')
 import RenameView = require('../views/rename-view')
 import Omni = require('../../omni-sharp-server/omni')
-import applyChanges = require('./lib/apply-changes')
+import Changes = require('./lib/apply-changes')
 
 class Rename {
     private renameView: RenameView
@@ -33,8 +33,11 @@ class Rename {
     }
 
     public applyAllChanges(changes: any[]) {
-        return _.each(changes, (change) => atom.workspace.open(change.FileName, undefined)
-            .then((editor) => { applyChanges(editor, change.Changes) }))
+        return _.each(changes, (change) => {
+            atom.workspace.open(change.FileName, undefined)
+            .then((editor) => {
+                Changes.applyChanges(editor, change.Changes)
+            })});
     }
 }
 export =  Rename

--- a/lib/omnisharp-atom/views/rename-view.ts
+++ b/lib/omnisharp-atom/views/rename-view.ts
@@ -35,7 +35,8 @@ class RenameView extends spacePenViews.View {
 
     public rename() {
         Omni.client.renamePromise(Omni.makeDataRequest({
-            RenameTo: this.miniEditor.getText()
+            RenameTo: this.miniEditor.getText(),
+            WantsTextChanges: true
         }));
         return this.destroy();
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
         "./lib/omnisharp-atom/features/go-to-definition.ts",
         "./lib/omnisharp-atom/features/go-to-implementation.ts",
         "./lib/omnisharp-atom/features/intellisense.ts",
+        "./lib/omnisharp-atom/features/lib/apply-changes.ts",
         "./lib/omnisharp-atom/features/lib/completion-provider.ts",
         "./lib/omnisharp-atom/features/lookup.ts",
         "./lib/omnisharp-atom/features/package-restore.ts",


### PR DESCRIPTION
Makes renaming smoother as it is only applying changes to documents instead of overwriting the entire document. 
![rename-fixed](https://cloud.githubusercontent.com/assets/667194/7556881/f6a0efec-f77b-11e4-8fb0-da5e1dd7e0f1.gif)

Currently contains a hack to remove dupes sent by the server. I'll remove the hack when https://github.com/OmniSharp/omnisharp-roslyn/issues/175 is fixed