### PR TITLE
remove hacky rename fix

### DIFF
--- a/lib/omnisharp-atom/features/rename.ts
+++ b/lib/omnisharp-atom/features/rename.ts
@@ -33,21 +33,9 @@ class Rename {
     }
 
     public applyAllChanges(changes: any[]) {
-        var grouped = _.groupBy(changes, 'FileName');
-
-        return _.each(grouped, (changesByFileName) => {
-            var fileName = changesByFileName[0].FileName;
-            var dedupedChanges = this.flattenAndDedupeChanges(changesByFileName);
-            atom.workspace.open(fileName, undefined)
-                .then((editor) => { Changes.applyChanges(editor, dedupedChanges); })
-        });
-    }
-
-    private flattenAndDedupeChanges(changes) {
-        // hacky workaround for a server issue that is waiting for a Roslyn fix.
-        var changeLists = _.map(changes, (change) => { return change.Changes; });
-        return  _.uniq(_.flatten(changeLists, true), false, (change) => {
-            return change.StartColumn * 17 + change.StartLine * 23 + change.EndColumn * 31 + change.EndLine;
+        return _.each(changes, (change) => {
+            atom.workspace.open(change.FileName, undefined)
+                .then((editor) => { Changes.applyChanges(editor, change.Changes); })
         });
     }
 }


### PR DESCRIPTION
We had a hack in the rename code to fix a server bug. The server has now been fixed https://github.com/OmniSharp/omnisharp-roslyn/pull/216, so removed the hack.