### PR TITLE
Removes depedency on autocomplete-plus 3rd party package, and bumps min version of atom

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "atom": ">=0.192.0 <2.0.0"
+    "atom": ">=0.199.0 <2.0.0"
   },
   "activationCommands": [],
   "menus": [
@@ -110,7 +110,6 @@
     "grunt-contrib-watch": "^0.6.1"
   },
   "package-dependencies": {
-    "autocomplete-plus": "^2.0.2",
     "language-csharp": ">=0.3.0",
     "linter": ">=0.12.0",
     "atom-yeoman": ">=0.1.5"


### PR DESCRIPTION
As of 199, autocomplete-plus is now in the core of atom. Removing the dependency on 3rd party package and bumps minimum required version of atom.

Seems to still "just work" with these config changes, might be worth double checking on a clean install if someone gets a chance.