### PR TITLE
Use UI Theme background color for pane colors to be more consistent

### DIFF
--- a/styles/omnisharp-atom.less
+++ b/styles/omnisharp-atom.less
@@ -109,7 +109,7 @@
   }
 
   pre {
-    background: #161719;
+    background: @base-background-color;
     font-size: 10px;
     margin: 0px;
     padding: 0px;
@@ -128,7 +128,7 @@
 
 .codecheck {
     padding-left: 20px;
-    background-color: #161719;
+    background-color: @base-background-color;
 
     &.Hidden, &.Warning {
         background-image: url('atom://omnisharp-atom/styles/icons/codecheck-warning.png');


### PR DESCRIPTION
Instead of a hardcoded background color for errors/output/etc, use the UI theme background color. We're already using the UI theme text colors for Error/Warning/etc. This makes the editing experience more consistent.

Bonus low quality gif:

![atom-pane-color](https://cloud.githubusercontent.com/assets/1507077/7644685/bc6ad01a-fa76-11e4-96dc-b01dcbc91b96.gif)
