### PR TITLE
Added developer flag to filter console.log

### DIFF
--- a/lib/omni-sharp-server/client.ts
+++ b/lib/omni-sharp-server/client.ts
@@ -82,7 +82,9 @@ class Client extends omnisharp.OmnisharpClient {
         });
 
         this.responses.subscribe(data => {
-            console.log("omni:" + data.command, data.request, data.response);
+            if (atom.config.get('omnisharp-atom.developerMode')) {
+                console.log("omni:" + data.command, data.request, data.response);
+            }
         });
     }
 

--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -218,6 +218,12 @@ class OmniSharpAtom {
             description: "Automatically starts Omnisharp Roslyn when a compatible file is opened.",
             type: 'boolean',
             default: true
+        },
+        developerMode: {
+            title: 'Developer Mode',
+            description: 'Outputs detailed server calls in console.log',
+            type: 'boolean',
+            default: false
         }
     }
 


### PR DESCRIPTION
Allows us to turn on or off the, er, generous server output in console.log.

It is disabled by default for those non-omnisharp devs that are using the package.

Closes #261 