### PR TITLE
Remove "Fix Usings" from menus

### DIFF
--- a/menus/atom-sharper.cson
+++ b/menus/atom-sharper.cson
@@ -9,7 +9,6 @@
         { 'label': 'Go to Definition', 'command': 'omnisharp-atom:go-to-definition' }
         { 'label': 'Go to Implementation', 'command': 'omnisharp-atom:go-to-implementation' }
         { 'label': 'Rename', 'command': 'omnisharp-atom:rename'}
-        { 'label': 'Fix Usings', 'command': 'omnisharp-atom:fix-usings' }
         { 'label': 'Code Format', 'command': 'omnisharp-atom:code-format' }
         { 'label': 'Lookup type', 'command': 'omnisharp-atom:type-lookup' }
       ]

--- a/menus/omnisharp-menu.json
+++ b/menus/omnisharp-menu.json
@@ -7,7 +7,6 @@
       { "label": "Go to Definition", "command": "omnisharp-atom:go-to-definition" },
       { "label": "Go to Implementation", "command": "omnisharp-atom:go-to-implementation" },
       { "label": "Rename", "command": "omnisharp-atom:rename"},
-      { "label": "Fix Usings", "command": "omnisharp-atom:fix-usings" },
       { "label": "Code Format", "command": "omnisharp-atom:code-format" },
       { "label": "Lookup type", "command": "omnisharp-atom:type-lookup" }
     ]


### PR DESCRIPTION
Omnisharp-Roslyn doesn't implement fix usings yet. There's an outstanding PR for it at https://github.com/OmniSharp/omnisharp-roslyn/pull/150. Once that's complete we can re-enable this.