### PR TITLE
Add new async API to client-manager.ts

### DIFF
--- a/lib/omni-sharp-server/client-manager.ts
+++ b/lib/omni-sharp-server/client-manager.ts
@@ -2,14 +2,16 @@ import _ = require('lodash')
 import path = require('path');
 import Client = require('./client');
 import {findCandidates, DriverState} from "omnisharp-client";
+import {Observable, AsyncSubject, RefCountDisposable, Disposable} from "rx";
 
 class ClientManager {
     private _clients: { [path: string]: Client } = {};
     private _configurations: ((client: Client) => void)[] = [];
     private _projectClientPaths: { [key: string]: string[] } = {};
     private _clientPaths: string[] = [];
-    private _paths: string[] = [];
+    private _projectPaths: string[] = [];
     private _activated = false;
+    private _temporaryClients: { [path: string]: RefCountDisposable } = {};
 
     public activate() {
         this._activated = true;
@@ -30,53 +32,89 @@ class ClientManager {
     }
 
     private updatePaths(paths: string[]) {
-        var newPaths = _.difference(paths, this._paths);
+        var newPaths = _.difference(paths, this._projectPaths);
         var removePaths = _.intersection(newPaths, _.keys(this._clients));
         var addedPaths = _.difference(newPaths, _.keys(this._clients));
 
         _.each(removePaths, project => {
-            var client = this._clients[project];
-            client.disconnect();
-            delete this._clients[project];
+            this.removeClient(project);
         });
 
         _.each(addedPaths, project => {
             var localPaths = this._projectClientPaths[project] = [];
             findCandidates(project, console).toPromise().then(candidates => {
                 for (var candidate of candidates) {
-                    localPaths.push(candidate);
-                    this._clientPaths.push(candidate);
-
-                    var client = new Client({
-                        projectPath: candidate
-                    });
-
-                    _.each(this._configurations, config => config(client));
-                    this._clients[candidate] = client;
-
-                    // Auto start, with a little delay
-                    if (atom.config.get('omnisharp-atom.autoStartOnCompatibleFile')) {
-                        _.delay(() => client.connect(), 1200);
-                    }
+                    this.addClient(candidate, localPaths);
                 }
             });
         });
 
-        this._paths = paths;
+        this._projectPaths = paths;
+    }
+
+    private addClient(candidate: string, localPaths: string[], delay = 1200, temporary?: boolean) {
+        localPaths.push(candidate);
+        this._clientPaths.push(candidate);
+
+        var client = new Client({
+            projectPath: candidate
+        });
+
+        _.each(this._configurations, config => config(client));
+        this._clients[candidate] = client;
+
+        if (temporary) {
+            var tempD = Disposable.create(() => {});
+            tempD.dispose();
+            this._temporaryClients[candidate] = new RefCountDisposable(tempD);
+        }
+
+        // Auto start, with a little delay
+        if (atom.config.get('omnisharp-atom.autoStartOnCompatibleFile')) {
+            _.delay(() => client.connect(), delay);
+        }
+
+        return client;
+    }
+
+    private removeClient(candidate: string) {
+        var refCountDisposable = this._temporaryClients[candidate]
+        if (refCountDisposable) {
+            refCountDisposable.dispose();
+            if (!refCountDisposable.isDisposed) {
+                return;
+            }
+
+            delete this._temporaryClients[candidate];
+        }
+
+        var client = this._clients[candidate];
+        delete this._clients[candidate];
+        client.disconnect();
+        _.pull(this._clientPaths, candidate);
     }
 
     public getClientForActiveEditor() {
         var editor = atom.workspace.getActiveTextEditor();
+        var client: Observable<Client>;
         if (editor)
-            return this.getClientForEditor(editor);
+            client = this.getClientForEditor(editor);
 
-        // No window is open
-        return this._clients[this._clientPaths[0]];
+        if (client) return client;
+        // No active text editor
+        return Observable.empty<Client>();
     }
 
     public getClientForEditor(editor: Atom.TextEditor) {
+        var client: Observable<Client>;
         if (!editor)
-            return;
+            // No text editor found
+            return Observable.empty<Client>();
+
+        if (!editor.getPath) {
+            // Not a text editor
+            return Observable.empty<Client>();
+        }
 
         var grammarName = editor.getGrammar().name;
         var valid = false;
@@ -85,47 +123,105 @@ class ClientManager {
 
         var filename = path.basename(editor.getPath());
         if (filename === 'project.json') {
-           valid = true;
+            valid = true;
         }
 
         if (!valid)
-            return;
+            // No valid text editor
+            return Observable.empty<Client>();
 
+
+        var p = (<any>editor).omniProject;
         // Not sure if we should just add properties onto editors...
         // but it works...
-        if ((<any>editor).omniProject) {
-            return this._clients[(<any>editor).omniProject];
+        if (p && (client = Observable.just(this._clients[p]))) {
+            if (this._temporaryClients[p]) {
+                this.setupDisposableForTemporaryClient(p, editor);
+            }
+
+            return client;
         }
 
         var location = editor.getPath();
-        var [intersect, client] = this.getClientForUnderlyingPath(location);
-        (<any>editor).omniProject = intersect;
-        return client;
+        var [intersect, clientInstance] = this.getClientForUnderlyingPath(location, grammarName);
+        p = (<any>editor).omniProject = intersect;
+        if (this._temporaryClients[p]) {
+            this.setupDisposableForTemporaryClient(p, editor);
+        }
+
+        if (clientInstance)
+            return Observable.just(clientInstance);
+
+        return this.findClientForUnderlyingPath(location)
+            .map(z => {
+                var [p, client, temporary] = z;
+                (<any>editor).omniProject = p;
+                if (temporary) {
+                    this.setupDisposableForTemporaryClient(p, editor);
+                }
+                return client;
+            });
     }
 
-    public getClientForPath(location: string) {
-        var [intersect, client] = this.getClientForUnderlyingPath(location);
-        return client;
-    }
-
-    private getClientForUnderlyingPath(location: string) : [string, Client] {
+    private getClientForUnderlyingPath(location: string, grammar?: string): [string, Client] {
         if (location === undefined) {
             return;
         }
 
-        var segments = location.split(path.sep);
-        var mappedLocations = segments.map((loc, index) => {
-            return _.take(segments, index + 1).join(path.sep);
-        });
-
-        // Look for the closest match first.
-        mappedLocations.reverse();
-
-        var intersect = _.intersection(mappedLocations, this._clientPaths);
-        if (intersect.length) {
-            return [intersect[0], this._clients[intersect[0]]];
+        if (grammar === 'C# Script File' || _.endsWith(location, '.csx')) {
+            // CSX are special, and need a client per directory.
+            var directory = path.dirname(location);
+            var csClient = this._clients[directory];
+            if (csClient)
+                return [directory, csClient];
+        } else {
+            var intersect = intersectPath(location, this._clientPaths);
+            if (intersect) {
+                return [intersect, this._clients[intersect]];
+            }
         }
+
         return [null, null];
+    }
+
+    private findClientForUnderlyingPath(location: string, grammar?: string): Observable<[string, Client, boolean]> {
+        var directory = path.dirname(location);
+        var project = intersectPath(directory, this._projectPaths);
+        var localPaths: string[];
+        if (project)
+            localPaths = this._projectClientPaths[project] = [];
+
+        var subject = new AsyncSubject<[string, Client, boolean]>();
+
+        var foundCandidates = findCandidates(directory, console)
+            .subscribe(candidates => {
+                var newCandidates = _.difference(candidates, this._clientPaths);
+                for (var candidate of candidates) {
+                    this.addClient(candidate, localPaths || [], 0, !project);
+                }
+
+                var intersect = intersectPath(location, this._clientPaths) || intersectPath(location, this._projectPaths);
+                if (intersect) {
+                    subject.onNext([intersect, this._clients[intersect], !project]); // The boolean means this client is temporary.
+                } else {
+                    subject.onError('Could not find a client for location ' + location);
+                }
+                subject.onCompleted();
+            });
+
+        return subject;
+    }
+
+    private setupDisposableForTemporaryClient(path: string, editor: Atom.TextEditor) {
+        if (!editor['__setup_temp__'] && this._temporaryClients[path]) {
+            var refCountDisposable = this._temporaryClients[path];
+            var disposable = refCountDisposable.getDisposable();
+            editor['__setup_temp__'] = true
+            editor.onDidDestroy(() => {
+                disposable.dispose();
+                this.removeClient(path);
+            });
+        }
     }
 
     public registerConfiguration(callback: (client: Client) => void) {
@@ -134,6 +230,21 @@ class ClientManager {
         _.each(this._clients, (client) => {
             callback(client);
         });
+    }
+}
+
+function intersectPath(location: string, paths: string[]): string {
+    var segments = location.split(path.sep);
+    var mappedLocations = segments.map((loc, index) => {
+        return _.take(segments, index + 1).join(path.sep);
+    });
+
+    // Look for the closest match first.
+    mappedLocations.reverse();
+
+    var intersect = (<any>_<string[]>(mappedLocations)).intersection(paths).first();
+    if (intersect) {
+        return intersect;
     }
 }
 

--- a/lib/omni-sharp-server/omni.ts
+++ b/lib/omni-sharp-server/omni.ts
@@ -37,20 +37,6 @@ class Omni {
         }
     }
 
-    public static get client() {
-        return manager.getClientForActiveEditor();
-    }
-
-    public static makeRequest(editor?: Atom.TextEditor, buffer?: TextBuffer.TextBuffer) {
-        var client = editor ? manager.getClientForEditor(editor)
-            : manager.getClientForActiveEditor();
-        return client.makeRequest(editor, buffer);
-    }
-
-    public static makeDataRequest<T>(data: T, editor?: Atom.TextEditor, buffer?: TextBuffer.TextBuffer) {
-        return manager.getClientForActiveEditor().makeDataRequest(data, editor, buffer);
-    }
-
     public static navigateTo(response: { FileName: string; Line: number; Column: number; }) {
         atom.workspace.open(response.FileName, undefined)
             .then((editor) => {
@@ -69,8 +55,9 @@ class Omni {
         this.vm.isNotOff = !this.vm.isOff;
         this.vm.isOn = state === DriverState.Connecting || state === DriverState.Connected;
         this.vm.isReady = state === DriverState.Connected;
-        this.vm.isNotReady = !this.vm.isReady
+        this.vm.isNotReady = !this.vm.isReady;
         this.vm.isNotError = !this.vm.isError;
+        this.vm.isError = state === DriverState.Error;
         this.vm.isLoadingOrReady = this.vm.isLoading || this.vm.isReady;
         this.vm.iconText = this.vm.isError ? "omni error occured" : "";
     }

--- a/lib/omnisharp-atom/features/code-check.ts
+++ b/lib/omnisharp-atom/features/code-check.ts
@@ -29,17 +29,18 @@ class CodeCheck {
     }
 
     public doCodeCheck(editor: Atom.TextEditor) {
-        var client = ClientManager.getClientForEditor(editor);
-        if (client && client.currentState === omnisharp.DriverState.Connected) {
-            _.debounce(() => {
-                var request = <OmniSharp.Models.FormatRangeRequest>client.makeRequest(editor);
-                client.updatebufferPromise(request)
-                    .then(() => {
-                    request.FileName = null;
-                    client.codecheck(request);
-                });
-            }, 500)();
-        }
+        ClientManager.getClientForEditor(editor).subscribe(client => {
+            if (client && client.currentState === omnisharp.DriverState.Connected) {
+                _.debounce(() => {
+                    var request = <OmniSharp.Models.FormatRangeRequest>client.makeRequest(editor);
+                    client.updatebufferPromise(request)
+                        .then(() => {
+                            request.FileName = null;
+                            client.codecheck(request);
+                        });
+                }, 500)();
+            }
+        });
     }
 }
 

--- a/lib/omnisharp-atom/features/find-usages.ts
+++ b/lib/omnisharp-atom/features/find-usages.ts
@@ -1,3 +1,4 @@
+import ClientManager = require('../../omni-sharp-server/client-manager');
 import Omni = require('../../omni-sharp-server/omni')
 import OmniSharpAtom = require('../omnisharp-atom')
 
@@ -10,7 +11,8 @@ class FindUsages {
 
     public activate() {
         OmniSharpAtom.addCommand("omnisharp-atom:find-usages", () => {
-            Omni.client.findusagesPromise(Omni.makeRequest())
+            ClientManager.getClientForActiveEditor()
+                .subscribe(client => client.findusages(client.makeRequest()));
             this.atomSharper.outputView.selectPane("find");
         });
     }

--- a/lib/omnisharp-atom/features/go-to-implementation.ts
+++ b/lib/omnisharp-atom/features/go-to-implementation.ts
@@ -1,3 +1,4 @@
+import ClientManager = require('../../omni-sharp-server/client-manager');
 import Omni = require('../../omni-sharp-server/omni')
 import OmniSharpAtom = require('../omnisharp-atom')
 
@@ -10,7 +11,8 @@ class GoToImplementation {
     }
 
     public goToImplementation() {
-        Omni.client.findimplementationsPromise(Omni.makeRequest());
+        ClientManager.getClientForActiveEditor()
+            .subscribe(client => client.findimplementations(client.makeRequest()));
     }
 
     public activate() {

--- a/lib/omnisharp-atom/features/lib/completion-provider.ts
+++ b/lib/omnisharp-atom/features/lib/completion-provider.ts
@@ -1,8 +1,9 @@
+import ClientManager = require('../../../omni-sharp-server/client-manager');
 import Omni = require('../../../omni-sharp-server/omni')
 
 import _ = require('lodash')
 import rx = require('rx')
-import escape = require("escape-html");
+var escape = require("escape-html");
 var filter = require('fuzzaldrin').filter;
 
 export interface RequestOptions {
@@ -35,19 +36,21 @@ var dataSource = (function() {
     var currentOptions: RequestOptions;
 
     function getResults(options: RequestOptions) {
-        return Omni.client.autocomplete(Omni.makeDataRequest<OmniSharp.Models.AutoCompleteRequest>({
-            WordToComplete: '',
-            WantDocumentationForEveryCompletionResult: false,
-            WantKind: true,
-            WantSnippet: true,
-            WantReturnType: true
-        }))
+        return ClientManager
+            .getClientForActiveEditor()
+            .flatMap(client=> client.autocomplete(client.makeDataRequest<OmniSharp.Models.AutoCompleteRequest>({
+                WordToComplete: '',
+                WantDocumentationForEveryCompletionResult: false,
+                WantKind: true,
+                WantSnippet: true,
+                WantReturnType: true
+            })))
             .map(completions => {
-            if (completions == null) {
-                completions = [];
-            }
-            return completions;
-        });
+                if (completions == null) {
+                    completions = [];
+                }
+                return completions;
+            });
     };
 
     function justResults(options: RequestOptions) {

--- a/lib/omnisharp-atom/features/navigate-up-down.ts
+++ b/lib/omnisharp-atom/features/navigate-up-down.ts
@@ -1,3 +1,4 @@
+import ClientManager = require('../../omni-sharp-server/client-manager');
 import Omni = require('../../omni-sharp-server/omni')
 import OmniSharpAtom = require('../omnisharp-atom');
 
@@ -5,11 +6,11 @@ class Navigate {
     private disposable: { dispose: () => void; };
 
     public navigateUp() {
-        Omni.client.navigateupPromise(Omni.makeRequest());
+        ClientManager.getClientForActiveEditor().subscribe(client => client.navigateup(client.makeRequest()));
     }
 
     public navigateDown() {
-        Omni.client.navigatedownPromise(Omni.makeRequest());
+        ClientManager.getClientForActiveEditor().subscribe(client => client.navigatedown(client.makeRequest()));
     }
 
     public activate() {

--- a/lib/omnisharp-atom/features/package-restore.ts
+++ b/lib/omnisharp-atom/features/package-restore.ts
@@ -1,4 +1,5 @@
 import path = require('path');
+import ClientManager = require('../../omni-sharp-server/client-manager');
 import Omni = require('../../omni-sharp-server/omni');
 import OmniSharpAtom = require('../omnisharp-atom');
 
@@ -19,9 +20,11 @@ class PackageRestore {
         var filename = path.basename(editor.getPath());
         if (filename === 'project.json') {
             return editor.getBuffer().onDidSave(() => {
-                Omni.client.filesChangedPromise([{
-                    FileName: editor.getPath()
-                }]);
+
+                ClientManager.getClientForEditor(editor)
+                    .subscribe(client => client.filesChanged([{
+                        FileName: editor.getPath()
+                    }]));
             });
         }
     }

--- a/lib/omnisharp-atom/linter.ts
+++ b/lib/omnisharp-atom/linter.ts
@@ -19,7 +19,7 @@ class LinterCSharp extends Linter.Linter {
     static syntax: string = "source.cs";
     static regex: string = "";
 
-    constructor(public editor : Atom.TextEditor) {
+    constructor(public editor: Atom.TextEditor) {
         super(editor);
         this.editor = editor;
     }
@@ -53,11 +53,10 @@ class LinterCSharp extends Linter.Linter {
             return;
         }
 
-        var client = ClientManager.getClientForEditor(this.editor);
-        if (client) {
-            client.codecheckPromise(Omni.makeRequest(this.editor))
-                .then(data => {
-
+        ClientManager
+            .getClientForEditor(this.editor)
+            .flatMap(client => client.codecheck(client.makeRequest(this.editor)))
+            .subscribe(data => {
                 var errors = _.map(data.QuickFixes, (error: OmniSharp.Models.DiagnosticLocation): LinterError => {
                     var line = error.Line - 1;
                     var column = error.Column - 1;
@@ -70,7 +69,7 @@ class LinterCSharp extends Linter.Linter {
                     }
 
                     return {
-                        message: `${error.Text} [${Omni.getFrameworks(error.Projects)}] `,
+                        message: `${error.Text} [${Omni.getFrameworks(error.Projects) }] `,
                         line: line + 1,
                         col: column,
                         level: level,
@@ -80,9 +79,7 @@ class LinterCSharp extends Linter.Linter {
                 });
 
                 return callback(errors)
-
             });
-        }
     }
 }
 

--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -211,7 +211,7 @@ class OmniSharpAtom {
         this.statusBarView && this.statusBarView.destroy();
         this.outputView && this.outputView.destroy();
         this.autoCompleteProvider && this.autoCompleteProvider.destroy();
-        Omni.client.disconnect();
+        ClientManager.disconnect();
     }
 
     public consumeStatusBar(statusBar) {

--- a/lib/omnisharp-atom/views/rename-view.ts
+++ b/lib/omnisharp-atom/views/rename-view.ts
@@ -3,6 +3,7 @@ var $ = spacePenViews.jQuery;
 var TextEditorView = <any>spacePenViews.TextEditorView;
 
 import Omni = require('../../omni-sharp-server/omni')
+import ClientManager = require('../../omni-sharp-server/client-manager');
 
 class RenameView extends spacePenViews.View {
     private wordToRename = null;
@@ -34,10 +35,11 @@ class RenameView extends spacePenViews.View {
     }
 
     public rename() {
-        Omni.client.renamePromise(Omni.makeDataRequest({
-            RenameTo: this.miniEditor.getText(),
-            WantsTextChanges: true
-        }));
+        ClientManager.getClientForActiveEditor()
+            .subscribe(client => client.rename(client.makeDataRequest({
+                RenameTo: this.miniEditor.getText(),
+                WantsTextChanges: true
+            })));
         return this.destroy();
     }
 


### PR DESCRIPTION
Removed old getters from omni.ts.
Updated all references to the client manager and old omni references to use the new api.

My hope is that this will stop all the null reference errors we keep seeing logged, because for whatever reason `Omni.client` happened to be null or undefined at that moment.