### PR TITLE
Use leftLabel and default styling in suggestions.

### DIFF
--- a/lib/omnisharp-atom/features/lib/completion-provider.ts
+++ b/lib/omnisharp-atom/features/lib/completion-provider.ts
@@ -121,11 +121,12 @@ export var CompletionProvider = {
         return {
             _search: item.CompletionText,
             snippet: item.Snippet,
-            type: item.Kind,
+            type: item.Kind.toLowercase(),
             iconHTML: this.renderIcon(item),
             displayText: escape(item.DisplayText),
             className: 'autocomplete-omnisharp-atom',
-            description: this.renderReturnType(item.ReturnType)
+            description: item.RequiredNamespaceImport,
+            leftLabel: item.ReturnType,
         }
     },
 
@@ -158,13 +159,6 @@ export var CompletionProvider = {
     },
 
     dispose() {
-    },
-
-    renderReturnType(returnType: string) {
-        if (returnType === null) {
-            return;
-        }
-        return `Returns: ${returnType}`;
     },
 
     renderIcon(item) {

--- a/lib/omnisharp-atom/features/lib/completion-provider.ts
+++ b/lib/omnisharp-atom/features/lib/completion-provider.ts
@@ -1,5 +1,6 @@
 import ClientManager = require('../../../omni-sharp-server/client-manager');
 import Omni = require('../../../omni-sharp-server/omni')
+import OmniSharpAtom = require('../../omnisharp-atom');
 
 import _ = require('lodash')
 import rx = require('rx')
@@ -119,7 +120,8 @@ export var CompletionProvider = {
 
     makeSuggestion(item: OmniSharp.Models.AutoCompleteResponse) {
         var description, leftLabel, iconHTML, type;
-        if atom.config.get('omnisharp-atom.useLeftLabelColumnForSuggestions') == true {
+
+        if (OmniSharpAtom.cfgUseLeftLabelColumnForSuggestions == true) {
             description = item.RequiredNamespaceImport;
             leftLabel = item.ReturnType;
         } else {
@@ -127,7 +129,7 @@ export var CompletionProvider = {
             leftLabel = '';
         }
 
-        if atom.config.get('omnisharp-atom.useIcons') == true {
+        if (OmniSharpAtom.cfgUseIcons == true) {
             iconHTML = this.renderIcon(item);
             type = item.Kind;
         } else {

--- a/lib/omnisharp-atom/features/lib/completion-provider.ts
+++ b/lib/omnisharp-atom/features/lib/completion-provider.ts
@@ -118,15 +118,32 @@ export var CompletionProvider = {
     excludeLowerPriority: false,
 
     makeSuggestion(item: OmniSharp.Models.AutoCompleteResponse) {
+        var description, leftLabel, iconHTML, type;
+        if atom.config.get('omnisharp-atom.useLeftLabelColumnForSuggestions') == true {
+            description = item.RequiredNamespaceImport;
+            leftLabel = item.ReturnType;
+        } else {
+            description = this.renderReturnType(item.ReturnType);
+            leftLabel = '';
+        }
+
+        if atom.config.get('omnisharp-atom.useIcons') == true {
+            iconHTML = this.renderIcon(item);
+            type = item.Kind;
+        } else {
+            iconHTML = null;
+            type = item.Kind.toLowerCase();
+        }
+
         return {
             _search: item.CompletionText,
             snippet: item.Snippet,
-            type: item.Kind.toLowercase(),
-            iconHTML: this.renderIcon(item),
+            type: type,
+            iconHTML: iconHTML,
             displayText: escape(item.DisplayText),
             className: 'autocomplete-omnisharp-atom',
-            description: item.RequiredNamespaceImport,
-            leftLabel: item.ReturnType,
+            description: description,
+            leftLabel: leftLabel,
         }
     },
 
@@ -159,6 +176,13 @@ export var CompletionProvider = {
     },
 
     dispose() {
+    },
+
+    renderReturnType(returnType: string) {
+        if (returnType === null) {
+            return;
+        }
+        return `Returns: ${returnType}`;
     },
 
     renderIcon(item) {

--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -49,6 +49,9 @@ class OmniSharpAtom {
     private _activeEditorObservable = this._activeEditor.replay(z => z, 1);
     public get activeEditor(): Observable<Atom.TextEditor> { return this._activeEditorObservable; }
 
+    public cfgUseIcons: boolean;
+    public cfgUseLeftLabelColumnForSuggestions: boolean;
+
     public activate(state) {
         atom.commands.add('atom-workspace', 'omnisharp-atom:toggle', () => this.toggle());
         atom.commands.add('atom-workspace', 'omnisharp-atom:new-application', () => this.generator.run("aspnet:app"));
@@ -160,6 +163,13 @@ class OmniSharpAtom {
             // This will tell us when the editor is no longer an appropriate editor
             this._activeEditor.onNext(null);
         });
+
+        atom.config.observe('omnisharp-atom.useIcons', (value) => {
+            this.cfgUseIcons = value;
+        })
+        atom.config.observe('omnisharp-atom.useLeftLabelColumnForSuggestions', (value) => {
+            this.cfgUseLeftLabelColumnForSuggestions = value;
+        })
     }
 
     private detectAutoToggleGrammar(editor: Atom.TextEditor) {

--- a/lib/omnisharp-atom/omnisharp-atom.ts
+++ b/lib/omnisharp-atom/omnisharp-atom.ts
@@ -273,6 +273,18 @@ class OmniSharpAtom {
             description: 'Advanced: This will show diagnostics for all open solutions.  NOTE: May take a restart or change to each server to take effect when turned on.',
             type: 'boolean',
             default: false
+        },
+        useLeftLabelColumnForSuggestions: {
+            title: 'Use Left-Label column in Suggestions',
+            description: 'Shows return types in a right-aligned column to the left of the completion suggestion text.',
+            type: 'boolean',
+            default: false
+        },
+        useIcons: {
+            title: 'Use unique icons for kind indicators in Suggestions',
+            description: 'Shows kinds with unique icons rather than autocomplete default styles.',
+            type: 'boolean',
+            default: true
         }
     }
 


### PR DESCRIPTION
It's uncommon for autocomplete providers to use the description box for return types, so I have instead used the leftLabel property to display the return type. This is a right-aligned column placed before the displayText that, by default, is slightly dimmed and is easier to read.

In addition, the description field is now used to show required namespace imports, and the type will use the default colorization in autocomplete for a few types. This could be expanded to correctly map each kind in C# to the default types in autocomplete, but for now it's able to colorize properties and methods similarly to other completion providers, in addition to the icons used in OmniSharp.

What it looks like (_I have personally disabled the icons for my own use, they are still enabled in this PR_):

![](http://i.imgur.com/w0eNsXO.png)

Naturally this doesn't quite match up with Visual Studio's presentation for IntelliSense completion suggestions, but I think it better conforms with what Atom users might expect when using completions. It is based more on what the [autocomplete-plus API shows in their wiki](https://github.com/atom/autocomplete-plus/wiki/Provider-API#suggestions).