### PR TITLE
disable alt+enter when code action window is already open

### DIFF
--- a/keymaps/omnisharp-code-actions.cson
+++ b/keymaps/omnisharp-code-actions.cson
@@ -1,0 +1,3 @@
+'.code-actions-overlay':
+  'alt-enter': '!unset'
+  'ctrl-.': '!unset'


### PR DESCRIPTION
Disables the alt+enter and ctrl+. keys when the code action window has focus