### PR TITLE
do not show inline error popup when autocomplete is open

### DIFF
--- a/styles/omnisharp-atom.less
+++ b/styles/omnisharp-atom.less
@@ -516,3 +516,11 @@ li.selected span.filename {
         .btn-variant(@background-color-error);
     }
 }
+body atom-text-editor.autocomplete-active {
+    #linter-inline {
+        display:none;
+    }
+}
+atom-text-editor::shadow.autocomplete-active .linter-highlight{
+        display:none;
+}


### PR DESCRIPTION
This prevents the inline error tooltip from linter to stay open while the autocomplete is open too, leading to a very noisy editing experience e.g:

![image](https://cloud.githubusercontent.com/assets/245275/9772757/8aa9ac16-573e-11e5-9bd5-d248c88654f6.png)