### PR TITLE
Fixing error when exiting feature button as its sometimes null

### DIFF
--- a/lib/omnisharp-atom/atom/feature-buttons.ts
+++ b/lib/omnisharp-atom/atom/feature-buttons.ts
@@ -156,7 +156,9 @@ class FeatureButtons implements OmniSharp.IFeature {
             },
             onMouseLeave: (e) => {
                 this.disposable.remove(tooltipDisposable);
-                tooltipDisposable.dispose();
+                if (tooltipDisposable) {
+                    tooltipDisposable.dispose();
+                }
             }
         });
 


### PR DESCRIPTION
I'm not sure if this is the right fix as it may elude to a problem else where. But occasionally the tooltipDisposable isn't set upon enter therefore is null upon exit. 

@david-driscoll any thoughts?