### PR TITLE
Fix #513 by returning true or false from lodash any callback function

### DIFF
--- a/lib/omnisharp-atom/features/command-runner.ts
+++ b/lib/omnisharp-atom/features/command-runner.ts
@@ -175,7 +175,7 @@ export class RunProcess {
     private bootRuntime(runtime: string) {
         var args = [this.command];
         // Support old way of doing things (remove at RC?)
-        if (any(['beta3', 'beta4', 'beta5', 'beta6'], x => runtime.indexOf(x))) {
+        if (any(['beta3', 'beta4', 'beta5', 'beta6'], x => runtime.indexOf(x) > -1)) {
             args.unshift('.');
         }
 


### PR DESCRIPTION
Currently when lodash.any callback function returns -1 for runtime.indexOf(x), lodash thinks it is truthy and appends . to the dnx command. So that beta7 and beta8 gets executed as `dnx . run` instead of `dnx run` as it should.