### PR TITLE
Fix #542 when process.env.HOME is undefined on win32

### DIFF
--- a/lib/omni-sharp-server/view-model.ts
+++ b/lib/omni-sharp-server/view-model.ts
@@ -169,7 +169,7 @@ export class ViewModel implements VMViewState, Rx.IDisposable {
 
                 var path = normalize(system.RuntimePath);
                 if (win32) {
-                    var processHome = normalize(process.env.HOME);
+                    var processHome = normalize(process.env.HOME || process.env.USERPROFILE);
                     // Handles the case where home path does not have a trailing slash.
                     if (_.startsWith(path, processHome)) {
                         path = path.replace(processHome, '');

--- a/spec/features/command-runner-spec.ts
+++ b/spec/features/command-runner-spec.ts
@@ -33,7 +33,7 @@ describe('Command Runner', () => {
         });
 
         if (win32) {
-            expect(result).toBe('abc/bin/dnx.exe');
+            expect(result).toBe('abc\\bin\\dnx.exe');
         } else {
             expect(result).toBe('abc/bin/dnx');
         }


### PR DESCRIPTION
Viewmodel runtimePath doesn't get set here on win32 Windows 8.1 because for me process.env.HOME is undefined, so it leads to an error down the road at https://github.com/OmniSharp/omnisharp-atom/blob/master/lib/omnisharp-atom/atom/command-runner.ts#L147