### PR TITLE
Removed spacebar as a confirming action for autocomplete-plus

### DIFF
--- a/lib/features/intellisense.ts
+++ b/lib/features/intellisense.ts
@@ -12,7 +12,7 @@ class Intellisense implements IFeature {
             cd.add(editor.onWillInsertText(event => {
                 if (event.text.length > 1) return;
 
-                if (event.text === " " || event.text === ";" || event.text === ".") {
+                if (event.text === ";" || event.text === ".") {
                     atom.commands.dispatch(atom.views.getView(editor), "autocomplete-plus:confirm");
                 }
             }));


### PR DESCRIPTION
Having spacebar confirming the autocompletion is just non-standard behavior.