### PR TITLE
Update for compatibility with Atom 1.23

### DIFF
--- a/dist/server/omnisharp-text-editor.js
+++ b/dist/server/omnisharp-text-editor.js
@@ -18,6 +18,8 @@ var _tsDisposables = require('ts-disposables');
 
 var _projectViewModel = require('./project-view-model');
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var contextItems = new Map();
@@ -60,8 +62,10 @@ var OmnisharpEditorContext = exports.OmnisharpEditorContext = function () {
             });
         }), solution.open({ FileName: editor.getPath() }).subscribe(), solution.updatebuffer({ FileName: editor.getPath(), FromDisk: true }, { silent: true }).subscribe(), function () {
             solution.disposable.add(solution.close({ FileName: editor.getPath() }).subscribe());
-        }, editor.getBuffer().onWillChange(function (change) {
-            _this.pushChange(change);
+        }, editor.getBuffer().onDidChangeText(function (event) {
+            var _changes;
+
+            (_changes = _this._changes).push.apply(_changes, _toConsumableArray(event.changes));
         }), editor.onDidStopChanging(function () {
             if (_this.hasChanges) {
                 solution.updatebuffer({ FileName: editor.getPath(), Changes: _this.popChanges() }, { silent: true });
@@ -106,11 +110,6 @@ var OmnisharpEditorContext = exports.OmnisharpEditorContext = function () {
                 this.set(name, contextItems.get(name));
             }
             return this._items.get(name);
-        }
-    }, {
-        key: 'pushChange',
-        value: function pushChange(change) {
-            this._changes.push(change);
         }
     }, {
         key: 'popChanges',

--- a/lib/server/omnisharp-text-editor.ts
+++ b/lib/server/omnisharp-text-editor.ts
@@ -60,8 +60,8 @@ export class OmnisharpEditorContext implements IDisposable {
             () => {
                 solution.disposable.add(solution.close({ FileName: editor.getPath() }).subscribe());
             },
-            editor.getBuffer().onWillChange((change: { oldRange: TextBuffer.Range; newRange: TextBuffer.Range; oldText: string; newText: string; }) => {
-                this.pushChange(change);
+            editor.getBuffer().onDidChangeText((event: {changes: IAtomTextChange[]}) => {
+                this._changes.push(...event.changes)
             }),
             editor.onDidStopChanging(() => {
                 if (this.hasChanges) {
@@ -120,10 +120,6 @@ export class OmnisharpEditorContext implements IDisposable {
             this.set(name, contextItems.get(name));
         }
         return <any>this._items.get(name);
-    }
-
-    public pushChange(change: IAtomTextChange) {
-        this._changes.push(change);
     }
 
     public popChanges() {


### PR DESCRIPTION
:wave: @david-driscoll, Thanks for maintaining this package!

In Atom 1.23, we'll be making a breaking change to the behavior of the `TextBuffer.onWillChange` method: an event object will no longer be passed to the method's callback. For a description of the change, see atom/text-buffer#270.

### The Breaking API Change

The reason that we're making this breaking change is that the `.onWillChange` method has been a source of performance problems in Atom when making many simultaneous changes to a buffer, for example when typing with many cursors. The problem is that the method used to get called once for each *individual* buffer change, which would result in a lot of computation per keystroke.

Now, we only call the `onWillChange` callbacks once for each buffer *transaction* (a grouping of changes that can be undone and redone as an atomic unit). Because of this, there is no longer a single `oldRange` and `newRange` associated with the call.

### The Fix to Your Code

You should be able to simply use the `TextBuffer.onDidChangeText` method instead. This method calls its callback at the *end* of a transaction instead of the beginning, so it is able to provide information about each change that occurred.

I apologize to you for not providing backwards-compatibility in this case. Because there were so few (~4) packages that use the `.onWillChange` method, we chose to just reach out to package maintainers individually, rather than trying to somehow keep old code working.